### PR TITLE
README: nit fix for markdown portability (newline)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project provides a [simple Java client for NATS](https://github.com/cloudfo
 an optional [Spring integration](https://github.com/cloudfoundry-community/java-nats/tree/master/client-spring) for using the client.
 
 To use the basic client in your project, add the following to your Maven pom.xml:
+
 ```xml
 <dependency>
     <groupId>com.github.cloudfoundry-community</groupId>


### PR DESCRIPTION
The missing newline before the fenced code block doesn't affect GitHub's renderer, but does affect others.  So add one tiny extra newline.
